### PR TITLE
Simplifying project deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,11 @@
 SECRET_KEY=django-insecure-ug67bb!lyca-aewcz)!lmhq54_yfsvb81%8)ni4y*0$9*0b&ti
 DEBUG=true
 ENV_NAME=local
+
+# database connection configuration
+DB_ENGINE=django.db.backends.postgresql
+POSTGRES_DB=postgres
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+DB_HOST=localhost
+DB_PORT=5432

--- a/.gitignore
+++ b/.gitignore
@@ -120,7 +120,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
+*.env
 .venv
 env/
 venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements.txt /app
+COPY ./src/ /app/
+RUN pip install --upgrade pip
+RUN pip install -r requirements.txt --no-cache-dir
+CMD ["gunicorn", "bronfood.wsgi:application", "--bind", "0:8000"]

--- a/infra/deploy_in_container.py
+++ b/infra/deploy_in_container.py
@@ -1,0 +1,32 @@
+import logging
+import os
+import time
+
+import psycopg2
+from dotenv import load_dotenv
+
+load_dotenv()
+
+logging.basicConfig(
+    level=logging.DEBUG, format='[%(asctime)s] [%(levelname)s] %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+logger.debug('Waiting for database connection')
+while True:
+    try:
+        psycopg2.connect(
+            host=os.getenv('DB_HOST'),
+            port=os.getenv('DB_PORT'),
+            password=os.getenv('POSTGRES_PASSWORD'),
+            user=os.getenv('POSTGRES_USER')
+        )
+        logger.debug('Successful connection')
+        break
+    except psycopg2.OperationalError:
+        logger.info('No connection to database, connection restarted')
+        time.sleep(5)
+os.system('python manage.py makemigrations')
+os.system('python manage.py migrate')
+# TODO: os.system('python manage.py collectstatic --noinput')
+os.system('gunicorn bronfood.wsgi:application --bind 0:8000')

--- a/infra/docker-compose.django_db.yml
+++ b/infra/docker-compose.django_db.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+
+services:
+  db:
+    image: postgres:15.3-alpine3.18
+    restart: always
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    env_file:
+      - ../.env
+
+  web:
+    build: ../
+    restart: always
+    volumes:
+      - ./deploy_in_container.py:/app/infra/deploy_in_container.py
+    depends_on:
+      - db
+    command: python infra/deploy_in_container.py
+    env_file:
+      - ../.env
+    ports:
+      - "8000:8000"
+
+volumes:
+  postgres_data:

--- a/infra/docker-compose.only_db.yml
+++ b/infra/docker-compose.only_db.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+
+services:
+  db:
+    image: postgres:15.3-alpine3.18
+    restart: always
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    env_file:
+      - ../.env
+    ports:
+      - "5432:5432"
+
+volumes:
+  postgres_data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 asgiref==3.7.2
 Django==4.2.7
+gunicorn==21.2.0
+packaging==23.2
+psycopg2-binary==2.9.6
 python-dotenv==1.0.0
 sqlparse==0.4.4
 tzdata==2023.3

--- a/src/bronfood/settings.py
+++ b/src/bronfood/settings.py
@@ -32,7 +32,7 @@ DEBUG = os.getenv('DEBUG')
 
 ENV_NAME = os.getenv('ENV_NAME', 'local')
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 
 
 # Application definition
@@ -82,8 +82,12 @@ WSGI_APPLICATION = 'bronfood.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+        'ENGINE': os.getenv('DB_ENGINE'),
+        'NAME': os.getenv('POSTGRES_DB'),
+        'USER': os.getenv('POSTGRES_USER'),
+        'PASSWORD': os.getenv('POSTGRES_PASSWORD'),
+        'HOST': os.getenv('DB_HOST'),
+        'PORT': os.getenv('DB_PORT')
     }
 }
 


### PR DESCRIPTION
# Описание

Было добавлено несколько файлов docker/docker-compose для развертывания.

# Как проверено?

Для запуска в контейнере только базы данных:

```
docker-compose -f infra/docker-compose.only_db.yml up -d
```
Приложение в этом случае запускается вручную

Cовместный запуск базы и приложения в контейнерах:

> [!WARNING]
> Необходимо изменить изменить `DB_HOST=db` в `.env`

```
docker-compose -f infra/docker-compose.django_db.yml up
```

## Почему без флага -d

В папке `/infra` есть скрипт `deploy_in_container.py` он выводит лог о подключении к базе данных. Для первого запуска этого сценария будет лучше его не вводить.