### PR TITLE
Функции создания и валидации введенного OTP 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ typing_extensions==4.8.0
 tzdata==2023.3
 uritemplate==4.1.1
 urllib3==2.1.0
+requests==2.31.0

--- a/src/bronfood/core/phone/exceptions.py
+++ b/src/bronfood/core/phone/exceptions.py
@@ -1,0 +1,2 @@
+class WrongOtpCode(Exception):
+    pass

--- a/src/bronfood/core/phone/service.py
+++ b/src/bronfood/core/phone/service.py
@@ -1,0 +1,51 @@
+from bronfood.core.phone.exceptions import WrongOtpCode
+from bronfood.core.phone.models import (IssueReason, PhoneSmsOtpVerification,
+                                        SmsMessage, SmsStatus)
+from bronfood.core.phone.utils import generate_otp
+from bronfood.core.useraccount.models import UserAccount
+
+INCORRECT_CODE_MESSAGE = 'Code: {code} does not match expected.'
+FAILURE_CREATE_OTP = (
+    'invalid data type, create_otp_verifacation accepts '
+    'arguments like: "UserAccount", "IssueReason", "SmsMessage".'
+)
+FAILURE_VALIDATE_OTP = (
+    'invalid data type, validate_otp_verifacation accepts '
+    'arguments like: "UserAccount" and str.'
+)
+
+
+def create_otp_verification(
+    user: UserAccount, issue_reason: IssueReason, message: SmsMessage
+) -> PhoneSmsOtpVerification | TypeError:
+    if not all(
+        (isinstance(user, UserAccount), isinstance(issue_reason, IssueReason),
+         isinstance(message, SmsMessage))
+    ):
+        raise TypeError(FAILURE_CREATE_OTP)
+    if existing_code := PhoneSmsOtpVerification.objects.filter(
+        sms_status=SmsStatus.PENDING, phone_number=user.phone
+    ).first():
+        existing_code.sms_status = SmsStatus.EXPIRED
+        existing_code.save()
+    return PhoneSmsOtpVerification.objects.create(
+        message=message,
+        code=generate_otp(user.phone),
+        user=user,
+        phone_number=user.phone,
+        sms_status=SmsStatus.PENDING,
+        issue_reason=issue_reason
+    )
+
+
+def validate_otp_verification(
+    user: UserAccount, code: str
+) -> bool | TypeError | WrongOtpCode:
+    if not all((isinstance(user, UserAccount), isinstance(code, str))):
+        raise TypeError(FAILURE_VALIDATE_OTP)
+    if existing_code := PhoneSmsOtpVerification.objects.filter(
+        sms_status=SmsStatus.PENDING, phone_number=user.phone, code=code
+    ).first():
+        existing_code.sms_status = SmsStatus.ACCEPTED
+        return existing_code.save() or True
+    raise WrongOtpCode(INCORRECT_CODE_MESSAGE.format(code=code))

--- a/src/bronfood/core/phone/utils.py
+++ b/src/bronfood/core/phone/utils.py
@@ -1,13 +1,13 @@
 from django.utils.crypto import get_random_string
 
-from bronfood.core.phone.models import PhoneSmsOtpVerification
+from bronfood.core.phone.models import PhoneSmsOtpVerification, SmsStatus
 
 
-def generate_otp(sms_status, phone_number):
+def generate_otp(phone_number):
     while True:
         code = get_random_string(length=4, allowed_chars='0123456789')
         if not PhoneSmsOtpVerification.objects.filter(
-            sms_status=sms_status,
+            sms_status=SmsStatus.PENDING,
             code=code,
             phone_number=phone_number,
         ).exists():

--- a/src/tests/core/phone/test_generate_otp.py
+++ b/src/tests/core/phone/test_generate_otp.py
@@ -1,9 +1,11 @@
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
+from bronfood.core.phone.exceptions import WrongOtpCode
 from bronfood.core.phone.models import (IssueReason, PhoneSmsOtpVerification,
                                         SmsMessage, SmsStatus)
-from bronfood.core.phone.utils import generate_otp
+from bronfood.core.phone.service import (create_otp_verification,
+                                         validate_otp_verification)
 
 User = get_user_model()
 
@@ -16,27 +18,51 @@ class GenerateOTPTest(TestCase):
         cls.user = User.objects.create_user(
             username='auth', phone=cls.phone_number
         )
-        cls.otp = PhoneSmsOtpVerification.objects.create(
-            message=SmsMessage.REGISTRATION,
-            user=cls.user,
-            phone_number=cls.phone_number,
-            sms_status=SmsStatus.PENDING,
-            issue_reason=IssueReason.REGISTRATION,
+
+    def test_create_otp(self):
+        otp = create_otp_verification(
+            GenerateOTPTest.user, IssueReason.REGISTRATION,
+            SmsMessage.REGISTRATION
+        )
+        self.assertEqual(len(otp.code), 4, 'Длина OTP должна быть равна 4.')
+        self.assertEqual(otp.code, GenerateOTPTest.user.otp.last().code,
+                         'Сгенерированный OTP не соответсвует пользователю.')
+        create_otp_verification(
+            GenerateOTPTest.user, IssueReason.REGISTRATION,
+            SmsMessage.REGISTRATION
+        )
+        self.assertEqual(
+            PhoneSmsOtpVerification.objects.get(pk=otp.id).sms_status,
+            SmsStatus.EXPIRED,
+            ('После повторной генерации должен изменится статус предыдущего '
+             'кода.')
+        )
+        self.assertRaises(
+            TypeError, create_otp_verification, None, None, None,
+            'Ожидается исключение при аргументах с неверным типом данных.'
         )
 
-    def test_generate_otp(self):
-        """
-        Verifying the generate_otp method of the PhoneSmsOtpVerification model.
-        """
-        GenerateOTPTest.otp.code = generate_otp(
-            SmsStatus.PENDING, GenerateOTPTest.otp.phone_number
-        )
-        GenerateOTPTest.otp.save()
-        self.assertEqual(
-            len(GenerateOTPTest.otp.code), 4, 'Длина OTP должна быть равна 4.'
+    def test_validate_otp(self):
+        otp = create_otp_verification(
+            GenerateOTPTest.user, IssueReason.REGISTRATION,
+            SmsMessage.REGISTRATION
         )
         self.assertEqual(
-            GenerateOTPTest.otp.code,
-            GenerateOTPTest.user.otp.last().code,
-            'Сгенерированный OTP не соответсвует пользователю!'
+            validate_otp_verification(GenerateOTPTest.user, otp.code), True,
+            'В случае успешной валидации ожидаемый возврат: True.'
         )
+        self.assertEqual(
+            PhoneSmsOtpVerification.objects.get(pk=otp.id).sms_status,
+            SmsStatus.ACCEPTED,
+            'После успешной валидации статус OTP кода меняется на ACCEPTED.'
+        )
+        with self.assertRaises(
+            WrongOtpCode, msg='Ожидается исключение при неверном OTP коде.'
+        ):
+            validate_otp_verification(GenerateOTPTest.user, '0000')
+
+        with self.assertRaises(
+            TypeError,
+            msg='Ожидается исключение при аргументах с неверным типом данных.'
+        ):
+            validate_otp_verification(None, None)


### PR DESCRIPTION
# Описание

Необходимы для методов API, которые требуют подтверждения.

# Как использовать 

```python
from bronfood.core.phone.models import IssueReason, SmsMessage, SmsStatus
from bronfood.core.phone.service import create_otp_verification, validate_otp_verification

# Любой эндпоинт
otp = create_otp_verification(user, IssueReason.Registration, SmsMessage.Registration)
 
if validate_otp_verification(user, code):
    # делаем необходимое после проверки
```