### PR TITLE
Feature/fix develop worlflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,10 +2,6 @@ name: CI
 
 on:
 
-  push:
-    branches:
-      - develop_next
-
   pull_request:
     types: [closed]
     branches:
@@ -15,7 +11,7 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || (github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop_next')
+    if: github.event.pull_request.merged == true
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,7 @@ name: CI
 
 on:
 
-  pull_request:
-    types: [closed]
+  push:
     branches:
       - develop_next
 
@@ -11,7 +10,6 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Workflow для девелоп ранее запускался дважды, так как исполнялись сразу 2 условия на запуск.
Оставил только 1 условие, которое считаю более общим и универсальным.

Условие срабатывает:

- Пуш новых коммитов: Если вы добавите новые коммиты в ветку develop_next и выполните команду git push origin develop_next, workflow запустится.
- Пуш тегов: Если вы создадите или обновите теги в ветке develop_next и выполните команду git push --tags, это также может запустить workflow, если конфигурация включает обработку тегов.
- Прямое пуш изменений: Если изменения вносятся непосредственно в ветку develop_next (например, через web-интерфейс GitHub), workflow будет запущен.
- Обновление ветки через слияние: Если в ветку develop_next сливаются изменения из другой ветки (например, через pull request), и этот merge приводит к созданию новых коммитов в develop_next, workflow будет запущен.